### PR TITLE
fix memory allocation error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,8 @@ if(MPI_FOUND)
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -flto -fomit-frame-pointer -finline-functions -march=native -funroll-loops -ftree-vectorize -fno-strict-aliasing")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -DMPI_COUPLING")
 else()
+    # uncoment if want to debug
+    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -flto -fomit-frame-pointer -finline-functions -march=native -funroll-loops -ftree-vectorize -fno-strict-aliasing")
 endif()
 
@@ -158,7 +160,7 @@ endif()
 # ----------------------------------
 # Main Project Executable
 # ----------------------------------
-set(INTERPRETER tools/forefire/ForeFire.cpp tools/forefire/AdvancedLineEditor.cpp)
+set(INTERPRETER tools/forefire/ForeFire.cpp)
 add_executable(forefire ${INTERPRETER})
 if(DEFINED NETCDF_STATIC_LIBS)
     if(MPI_FOUND)


### PR DESCRIPTION
**1. How we found the issue:**
*   The crash consistently occurred during program termination.
*   **Valgrind** reported a "double free" error. Crucially, it showed the problematic memory (a large `std::string`) was allocated during static initialization within code compiled into the main `forefire` executable (`bin/forefire`). The invalid *second* free attempt originated from the destructor of a static object within the `libforefireL.so` library.
*   **GDB, attached to Valgrind,** confirmed the invalid free was triggered by `__do_global_dtors_aux` in `libforefireL.so`.
*   Valgrind's allocation stack trace pointed directly to the static initialization of a global `std::string commandHelp` (defined in `commands.md` and included by `AdvancedLineEditor.cpp`) and the associated static `cmdMan` map within `AdvancedLineEditor.cpp`.

**2. What the issue was:**
*   The file `tools/forefire/AdvancedLineEditor.cpp` (which `#include`s `commands.md` to define a global `std::string commandHelp`) was being compiled into *both* the main `forefire` executable and the `libforefireL.so` shared library.
*   This resulted in two separate instances of the large static `std::string commandHelp` and the static `std::unordered_map cmdMan` that uses it – one in the executable and one in the library.
*   Upon program exit, both instances were destructed. The `std::string` allocated by the executable's instance was correctly freed. However, the library's static object destructor chain was somehow attempting to free this *same* memory again (or memory aliased to it by the linker/compiler for such large static strings), leading to the "double free."

**3. How we fixed it:**
*   The fix was to ensure that `AdvancedLineEditor.cpp` (and therefore its static objects `commandHelp` and `cmdMan`) is compiled **only once**, as part of the `libforefireL.so` library.
*   In `CMakeLists.txt`, `tools/forefire/AdvancedLineEditor.cpp` was removed from the source list for the `forefire` executable target (`INTERPRETER` variable). It remains part of the `forefireL` library target.
*   The `forefire` executable now links against `libforefireL.so` and uses the single, correctly managed instance of these static objects from the library. This eliminates the duplicate static objects and the resulting double free.

Best regards,
Antonio (and the ForeFire AI Assistant)
