### PR TITLE
add bboxwesn attribute to save netcdf

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -2158,6 +2158,12 @@ namespace libforefire
 
             domVar.putAtt("type", "domain");
 
+            std::string bboxwsen = simParam->getParameter("BBoxWSEN");
+            if (!bboxwsen.empty())
+            {
+                domVar.putAtt("BBoxWSEN", bboxwsen.c_str());
+            }
+
             std::string wsenlbrt = simParam->getParameter("WSENLBRT");
             if (!wsenlbrt.empty())
             {


### PR DESCRIPTION
### Problem: 
When creating a landscape using pyforefire, the domain attributes is not equal to the data.nc provided in tests/runff.

### Proposed solution: 
Add the string BBoxWSEN in the same way as WSENLBRT 