### PR TITLE
[Dockerfile] Review Dockerfile adding python and bash entrypoint #103

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ COPY . .
 RUN sh cmake-build.sh
 
 # add executable to PATH
-RUN cp /forefire/bin/forefire /bin
+RUN cp /forefire/bin/forefire /usr/local/bin/
+
+# Set the entrypoint to bash for interactive sessions
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The easiest way to get started is often using Docker and the interactive console
 3. Run the container interactively
 
     ```bash
-    docker run -it --rm -p 8000:8000 --name ff_interactive forefire bash
+    docker run -it --rm -p 8000:8000 --name ff_interactive forefire
     ```
 4. Inside the container navigate to test directory and launch the forefire console:
     ```bash

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -34,7 +34,7 @@ Steps
   
   .. code-block:: bash
 
-    docker run -it --rm -p 8000:8000 --name ff_interactive forefire bash
+    docker run -it --rm -p 8000:8000 --name ff_interactive forefire
 
 4.  **Inside the container, navigate to the test directory:**
 

--- a/tools/docker/Dockerfile.base
+++ b/tools/docker/Dockerfile.base
@@ -1,16 +1,10 @@
 FROM ubuntu:22.04
 
-# Install build tools, ForeFire dependencies, AND Python environment
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     libnetcdf-c++4-dev \
-    cmake \
-    python3 \
-    python3-pip \
-    python3-dev \
-    git && \
-    rm -rf /var/lib/apt/lists/*
+    cmake
 
 WORKDIR /forefire
 ENV FOREFIREHOME=/forefire
@@ -18,14 +12,11 @@ ENV FOREFIREHOME=/forefire
 # we could only copy src, cmakelists.txt and cmake-build.sh
 COPY . .
 
-# Build and install the ForeFire C++ library
+# install forefire
 RUN sh cmake-build.sh
 
-# Add the main forefire executable to the PATH
+# add executable to PATH
 RUN cp /forefire/bin/forefire /usr/local/bin/
-
-# Use pip to install the Python dependencies defined in pyproject.toml
-RUN pip3 install ./bindings/python
 
 # Set the entrypoint to bash for interactive sessions
 CMD ["bash"]

--- a/tools/docker/Dockerfile.multistage
+++ b/tools/docker/Dockerfile.multistage
@@ -1,0 +1,60 @@
+# File: tools/Dockerfile.multistage
+# Target: Creates an optimized, smaller final image using a multi-stage build.
+# Contains full Python support.
+
+# --- STAGE 1: The "Builder" ---
+# This stage is a temporary environment used to compile the C++ code.
+# It contains all the heavy build tools, which will NOT be in the final image.
+FROM ubuntu:22.04 AS builder
+
+# Install build tools and C++ dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    libnetcdf-c++4-dev \
+    cmake \
+    git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Copy all source code into the builder stage
+COPY . .
+
+# Build the C++ library and executable
+RUN sh cmake-build.sh
+
+
+# --- STAGE 2: The "Final Image" ---
+# This is the final, clean image that will be distributed.
+# It starts from a fresh Ubuntu base and only pulls in what's necessary.
+FROM ubuntu:22.04
+
+# Install only the RUNTIME dependencies needed for ForeFire and the Python bindings.
+# As requested, we use libnetcdf-c++4-dev here for consistency with the build stage.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libnetcdf-c++4-dev \
+    libgomp1 \
+    python3 \
+    g++ \
+    python3-pip \
+    python3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /forefire
+ENV FOREFIREHOME=/forefire
+
+# The magic step: Copy the ENTIRE built project from the 'builder' stage.
+# This brings over the compiled libs, binaries, and the source code needed for the bindings.
+COPY --from=builder /src/ .
+
+# Add the forefire executable to the system's PATH
+RUN cp /forefire/bin/forefire /usr/local/bin/
+
+# Install the Python bindings and their dependencies (numpy, etc.)
+# This compiles the C++ extension using the headers we just copied.
+RUN pip3 install ./bindings/python
+
+# Set the default command to start a bash shell
+CMD ["bash"]

--- a/tools/docker/readme.md
+++ b/tools/docker/readme.md
@@ -1,0 +1,10 @@
+## Alternative Dockerfiles
+
+WIP
+
+- Dockerfile without python to make the image smaller 
+- Multistage build to make the also smaller (490 vs 620 mb)
+
+```
+docker build -f tools/docker/Dockerfile.multistage -t forefire:multistage .
+```


### PR DESCRIPTION
## Main dockerfile
- installs python and pyforefire
- adds CMD ["bash"]

## Docker folder inside /tools
- Base dockerfile without python
- Multistage dockerfile for smaller images

